### PR TITLE
Disable building tests by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,7 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 include(get_cpm)
 
-option(BUILD_MATH_TESTS ON "Build unit-tests for math library")
-set(BUILD_MATH_TESTS ON)
+option(BUILD_MATH_TESTS OFF "Build unit-tests for math library")
 
 add_subdirectory("math")
 add_subdirectory("app")


### PR DESCRIPTION
Remove CMake option `BUILD_MATH_TESTS` setting to build tests.
Set option value to `OFF`. 